### PR TITLE
Unify printing of log messages

### DIFF
--- a/libsdhcdrivers/src/mmc.c
+++ b/libsdhcdrivers/src/mmc.c
@@ -77,10 +77,10 @@ static int mmc_decode_cid(mmc_card_t mmc_card, struct cid *cid)
         cid->sd_cid.date    = slice_bits(mmc_card->raw_cid,   8, 12);
 
         ZF_LOGD("manfid(%x), oemid(%x), name(%c%c%c%c%c), rev(%x), serial(%x), date(%x)",
-               cid->manfid, cid->sd_cid.oemid,
-               cid->sd_cid.name[0], cid->sd_cid.name[1], cid->sd_cid.name[2],
-               cid->sd_cid.name[3], cid->sd_cid.name[4],
-               cid->sd_cid.rev, cid->sd_cid.serial, cid->sd_cid.date);
+                cid->manfid, cid->sd_cid.oemid,
+                cid->sd_cid.name[0], cid->sd_cid.name[1], cid->sd_cid.name[2],
+                cid->sd_cid.name[3], cid->sd_cid.name[4],
+                cid->sd_cid.rev, cid->sd_cid.serial, cid->sd_cid.date);
     } else {
         ZF_LOGD("Not Implemented!");
         return -1;

--- a/libsdhcdrivers/src/plat/exynos4/sdio.c
+++ b/libsdhcdrivers/src/plat/exynos4/sdio.c
@@ -51,13 +51,13 @@ int sdio_init(enum sdio_id id, ps_io_ops_t *io_ops, sdio_host_dev_t *dev)
         return -1;
     }
     if (iobase == NULL) {
-        LOG_ERROR("Failed to map device memory for SDHC\n");
+        ZF_LOGE("Failed to map device memory for SDHC");
         return -1;
     }
 
     ret = sdhc_init(iobase, _sdhc_irq_table, NSDHC, io_ops, dev);
     if (ret) {
-        LOG_ERROR("Failed to initialise SDHC\n");
+        ZF_LOGE("Failed to initialise SDHC");
         return -1;
     }
     return 0;

--- a/libsdhcdrivers/src/plat/imx6/sdio.c
+++ b/libsdhcdrivers/src/plat/imx6/sdio.c
@@ -47,13 +47,13 @@ int sdio_init(enum sdio_id id, ps_io_ops_t *io_ops, sdio_host_dev_t *dev)
         return -1;
     }
     if (iobase == NULL) {
-        LOG_ERROR("Failed to map device memory for SDHC\n");
+        ZF_LOGE("Failed to map device memory for SDHC");
         return -1;
     }
 
     ret = sdhc_init(iobase, _sdhc_irq_table, NSDHC, io_ops, dev);
     if (ret) {
-        LOG_ERROR("Failed to initialise SDHC\n");
+        ZF_LOGE("Failed to initialise SDHC");
         return -1;
     }
     return 0;


### PR DESCRIPTION
The driver is inconsistent in the way it logs messages. It makes use of a mix of deprecated logging macros and printf().
With the current PR, this will all be cleaned up and unified to the currently relevant ZF_LOG... macros.