### PR TITLE
github: style check on diff only for this repo

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,3 +31,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/style@master
+      with:
+        diff_only: true


### PR DESCRIPTION
This repository is not yet fully style-clean, and the policy is to
update files as we touch them, not in one big go. Until we have reached
a fully style-clean state, we should check only the diff on push, not
all files.
