### PR TITLE
libusbdrivers: fix inverted error check

### DIFF
--- a/libusbdrivers/src/services.h
+++ b/libusbdrivers/src/services.h
@@ -23,16 +23,16 @@ static inline void *usb_malloc(size_t size)
 {
     int ret;
 
-	if (ps_malloc_ops && ps_malloc_ops->calloc) {
-		void *ptr;
-		ret = ps_calloc(ps_malloc_ops, 1, size, &ptr);
-		if (!ret) {
-			ZF_LOGF("Malloc error\n");
-		}
-		return ptr;
-	} else {
-		return calloc(1, size);
-	}
+    if (ps_malloc_ops && ps_malloc_ops->calloc) {
+        void *ptr;
+        ret = ps_calloc(ps_malloc_ops, 1, size, &ptr);
+        if (0 != ret) {
+            ZF_LOGF("Malloc error %d\n", ret);
+        }
+        return ptr;
+    } else {
+        return calloc(1, size);
+    }
 }
 
 static inline void usb_free(void *ptr)

--- a/libusbdrivers/src/services.h
+++ b/libusbdrivers/src/services.h
@@ -5,13 +5,13 @@
  */
 #pragma once
 
-#include <stdlib.h>
-#include <platsupport/io.h>
 #include <platsupport/delay.h>
+#include <platsupport/io.h>
+#include <stdlib.h>
+#include <usb/usb_host.h>
 #include <utils/ansi.h>
 #include <utils/util.h>
 #include <utils/zf_log.h>
-#include <usb/usb_host.h>
 
 void otg_irq(void);
 
@@ -21,7 +21,7 @@ void otg_irq(void);
 extern ps_malloc_ops_t *ps_malloc_ops;
 static inline void *usb_malloc(size_t size)
 {
-	int ret;
+    int ret;
 
 	if (ps_malloc_ops && ps_malloc_ops->calloc) {
 		void *ptr;
@@ -37,49 +37,48 @@ static inline void *usb_malloc(size_t size)
 
 static inline void usb_free(void *ptr)
 {
-	int ret;
+    int ret;
 
-	if (ps_malloc_ops && ps_malloc_ops->free) {
-		ret = ps_free(ps_malloc_ops, 1, ptr);
-		if (!ret) {
-			ZF_LOGF("Free error\n");
-		}
-	} else {
-		free(ptr);
-	}
+    if (ps_malloc_ops && ps_malloc_ops->free) {
+        ret = ps_free(ps_malloc_ops, 1, ptr);
+        if (!ret) {
+            ZF_LOGF("Free error\n");
+        }
+    } else {
+        free(ptr);
+    }
 }
 
 static inline void dsb()
 {
 #ifdef ARCH_ARM
-	asm volatile("dsb");
+    asm volatile("dsb");
 #else
-	asm volatile ("" ::: "memory");
+    asm volatile("" ::
+                 : "memory");
 #endif
 }
 
-static inline void *ps_dma_alloc_pinned(ps_dma_man_t * dma_man, size_t size,
-					int align, int cache,
-					ps_mem_flags_t flags, uintptr_t * paddr)
+static inline void *ps_dma_alloc_pinned(ps_dma_man_t *dma_man, size_t size,
+                                        int align, int cache,
+                                        ps_mem_flags_t flags, uintptr_t *paddr)
 {
-	void *addr;
-	if (!dma_man) {
-		ZF_LOGF("Invalid arguments\n");
-	}
-	addr = ps_dma_alloc(dma_man, size, align, cache, flags);
-	if (addr != NULL) {
-		*paddr = ps_dma_pin(dma_man, addr, size);
-	}
-	return addr;
+    void *addr;
+    if (!dma_man) {
+        ZF_LOGF("Invalid arguments\n");
+    }
+    addr = ps_dma_alloc(dma_man, size, align, cache, flags);
+    if (addr != NULL) {
+        *paddr = ps_dma_pin(dma_man, addr, size);
+    }
+    return addr;
 }
 
-static inline void
-ps_dma_free_pinned(ps_dma_man_t * dma_man, void *addr, size_t size)
+static inline void ps_dma_free_pinned(ps_dma_man_t *dma_man, void *addr, size_t size)
 {
-	if (!dma_man) {
-		ZF_LOGF("Invalid arguments\n");
-	}
-	ps_dma_unpin(dma_man, addr, size);
-	ps_dma_free(dma_man, addr, size);
+    if (!dma_man) {
+        ZF_LOGF("Invalid arguments\n");
+    }
+    ps_dma_unpin(dma_man, addr, size);
+    ps_dma_free(dma_man, addr, size);
 }
-


### PR DESCRIPTION
I believe that `ps_calloc` returns an error code which is 0 on success, since the pointer to the allocation is instead returned by an out parameter.

Signed-off-by: Kevin Tran <z5164322@unsw.edu.au>