### PR TITLE
usbdrivers, trivial: fix free error check

### DIFF
--- a/libusbdrivers/src/services.h
+++ b/libusbdrivers/src/services.h
@@ -41,7 +41,7 @@ static inline void usb_free(void *ptr)
 
     if (ps_malloc_ops && ps_malloc_ops->free) {
         ret = ps_free(ps_malloc_ops, 1, ptr);
-        if (!ret) {
+        if (ret != 0) {
             ZF_LOGF("Free error\n");
         }
     } else {


### PR DESCRIPTION
ps_free will always return 0. Therefore, the error check was always triggering, causing a ZF_LOGF statement to trigger.